### PR TITLE
linting.yml: add pull_request as workflow trigger

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,6 @@
 name: Python Flake8, black and pylint code quality check
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   lint:


### PR DESCRIPTION
This PR adapts the trigger for the linting workflow to `on: [push, pull_request]`, such that the workflow is also started when PRs are started from forks